### PR TITLE
Use configured JIRA domain for Notion issue links

### DIFF
--- a/app/notion_client.py
+++ b/app/notion_client.py
@@ -9,6 +9,7 @@ logger = logging.getLogger(__name__)
 
 NOTION_API_KEY = os.getenv("NOTION_API_KEY")
 NOTION_DATABASE_ID = os.getenv("NOTION_DATABASE_ID")
+JIRA_DOMAIN = os.getenv("JIRA_DOMAIN")
 
 notion = AsyncClient(auth=NOTION_API_KEY)
 
@@ -400,7 +401,7 @@ async def create_notion_page(issue: JiraIssue):
                                 "type": "text",
                                 "text": {
                                     "content": key_content,
-                                    "link": {"url": f"https://example.atlassian.net/browse/{key_content}"}
+                                    "link": {"url": f"{JIRA_DOMAIN}/browse/{key_content}"}
                                 }
                             }
                         ]


### PR DESCRIPTION
## Summary
- Build Jira issue links using `JIRA_DOMAIN` env var instead of a fixed domain

## Testing
- `python -m py_compile app/notion_client.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5172ccdd0833397a0ba21bfd2b9df