### PR TITLE
Translate codebase text to English

### DIFF
--- a/app/filters.py
+++ b/app/filters.py
@@ -5,12 +5,12 @@ import logging
 logger = logging.getLogger(__name__)
 
 def filter_issues_by_assignee(issues: List[JiraIssue], assignee: str) -> List[JiraIssue]:
-    """Filtra los issues asignados al usuario con el display name proporcionado."""
-    logger.info(f"Ejecutando filtro para el asignado: {assignee}")
+    """Filter issues assigned to the user with the provided display name."""
+    logger.info(f"Running filter for assignee: {assignee}")
     filtered_issues = [
         issue for issue in issues
         if issue.displayName and issue.displayName.lower() == assignee.lower()
     ]
-    logger.info(f"Se encontraron {len(filtered_issues)} issues asignados a {assignee}")
+    logger.info(f"Found {len(filtered_issues)} issues assigned to {assignee}")
     return filtered_issues
 

--- a/app/issue_processor.py
+++ b/app/issue_processor.py
@@ -4,27 +4,25 @@ from .notion_client import create_or_update_notion_page, create_notion_page, upd
 from .filters import filter_issues_by_assignee
 from .logger_config import setup_logger
 from .config import settings
-from .notion_client import find_notion_page_by_ticket, set_notion_verificado
+from .notion_client import find_notion_page_by_ticket, set_notion_verified
 from fastapi import HTTPException
 
 
 logger = setup_logger()
 
 async def process_updated_issues(last_key):
-    """
-    Procesa los issues actualizados desde el último issue registrado.
-    """
+    """Process issues updated since the last recorded issue."""
     issues = await get_updated_issues()
 
     if not issues:
-        logger.info("No hay nuevos issues ni actualizaciones.")
+        logger.info("No new issues or updates.")
         return {"message": "No new updates."}
     
     last_processed_issue = None
 
     for issue in issues:
         issue_key = issue.key
-        logger.info(f"Procesando issue actualizado: {issue_key}")
+        logger.info(f"Processing updated issue: {issue_key}")
         await create_or_update_notion_page(issue)
         last_processed_issue = issue_key
 
@@ -32,61 +30,61 @@ async def process_updated_issues(last_key):
 
 async def process_new_issues(last_processed_issue_key):
     try:
-        logger.info("Iniciando verificación de nuevos issues en Jira")
+        logger.info("Starting check for new issues in Jira")
         issues = await get_new_issues()
         
         if issues:
-            logger.info(f"Se obtuvieron {len(issues)} issues nuevos desde Jira")
+            logger.info(f"Retrieved {len(issues)} new issues from Jira")
             filtered_issues = filter_issues_by_assignee(issues, settings.jira_assignee)
             
             if filtered_issues:
                 latest_issue = filtered_issues[0]
                 if latest_issue.key != last_processed_issue_key:
-                    logger.info(f"Nuevo issue detectado: {latest_issue.key}")
+                    logger.info(f"New issue detected: {latest_issue.key}")
                     
                     await create_or_update_notion_page(latest_issue)
                     last_processed_issue_key = latest_issue.key
                     
-                    logger.info(f"Página de Notion creada o actualizada para el issue: {latest_issue.key}")
-                    return {"message": "Nuevo issue procesado", "issue_key": latest_issue.key}
+                    logger.info(f"Notion page created or updated for issue: {latest_issue.key}")
+                    return {"message": "New issue processed", "issue_key": latest_issue.key}
                 else:
-                    logger.info(f"No hay nuevos issues asignados a {settings.jira_assignee}")
-                    return {"message": "No hay nuevos issues"}
+                    logger.info(f"No new issues assigned to {settings.jira_assignee}")
+                    return {"message": "No new issues"}
             else:
-                logger.info(f"No hay issues asignados a {settings.jira_assignee} en esta actualización")
-                return {"message": f"No hay issues asignados a {settings.jira_assignee} en esta actualización"}
+                logger.info(f"No issues assigned to {settings.jira_assignee} in this update")
+                return {"message": f"No issues assigned to {settings.jira_assignee} in this update"}
         else:
-            logger.info("No se encontraron issues nuevos en Jira")
-            return {"message": "No hay nuevos issues"}
+            logger.info("No new issues found in Jira")
+            return {"message": "No new issues"}
     except Exception as e:
-        logger.error(f"Error en el procesamiento de nuevos issues: {e}")
+        logger.error(f"Error processing new issues: {e}")
         raise
 
 async def periodic_task(last_processed_issue_key):
     while True:
         try:
             issues = await get_updated_issues()
-            logger.info(f"Se obtuvieron {len(issues)} issues actualizados")
+            logger.info(f"Fetched {len(issues)} updated issues")
             filtered_issues = filter_issues_by_assignee(issues, settings.jira_assignee)
             
             if filtered_issues:
                 latest_issue = filtered_issues[0]
                 if latest_issue.key != last_processed_issue_key:
-                    logger.info(f"Nuevo issue o actualización detectado: {latest_issue.key}")
+                    logger.info(f"New issue or update detected: {latest_issue.key}")
 
                     await create_or_update_notion_page(latest_issue)
                     last_processed_issue_key = latest_issue.key
                 else:
-                    logger.info("No hay nuevos issues ni actualizaciones.")
+                    logger.info("No new issues or updates.")
             else:
-                logger.info(f"No hay issues asignados a {settings.jira_assignee}.")
+                logger.info(f"No issues assigned to {settings.jira_assignee}.")
         except Exception as e:
-            logger.error(f"Error en la tarea periódica: {e}")
+            logger.error(f"Error in periodic task: {e}")
         await asyncio.sleep(settings.check_interval)
 
 async def sync_all_user_issues():
     try:
-        logger.info("Iniciando sincronización completa de issues asignados al usuario")
+        logger.info("Starting full synchronization of issues assigned to the user")
 
         jql = (
             'assignee = currentUser() AND '
@@ -98,29 +96,29 @@ async def sync_all_user_issues():
         issues = await _fetch_issues(jql)
 
         if not issues:
-            return {"message": "No hay issues asignados a este usuario."}
+            return {"message": "No issues assigned to this user."}
 
         processed_issues = []
 
         for issue in issues:
             issue_key = issue.key
-            logger.info(f"Sincronizando issue: {issue_key}")
+            logger.info(f"Synchronizing issue: {issue_key}")
 
             existing_page = await find_notion_page_by_ticket(issue_key)
 
             if existing_page:
-                logger.info(f"Actualizando estado a 'Inicial' para la página existente de {issue_key}")
-                await set_notion_verificado(existing_page, False)
+                logger.info(f"Updating status to 'Initial' for the existing page of {issue_key}")
+                await set_notion_verified(existing_page, False)
                 await update_notion_page(existing_page["id"], issue)
             else:
-                logger.info(f"Creando nueva página en Notion con estado 'Inicial' para {issue_key}")
+                logger.info(f"Creating new Notion page with status 'Initial' for {issue_key}")
                 await create_notion_page(issue)
 
             processed_issues.append(issue_key)
 
-        return {"message": f"Sincronizados {len(processed_issues)} issues", "issues": processed_issues}
+        return {"message": f"Synchronized {len(processed_issues)} issues", "issues": processed_issues}
 
     except Exception as e:
-        logger.error(f"Error en sincronización completa: {e}", exc_info=True)
+        logger.error(f"Error in full synchronization: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))
 

--- a/app/jira_client.py
+++ b/app/jira_client.py
@@ -8,7 +8,7 @@ JIRA_DOMAIN = os.getenv("JIRA_DOMAIN")
 JIRA_PROJECT_KEY = os.getenv("JIRA_PROJECT_KEY")
 
 async def check_jira_connection() -> bool:
-    """Verifica la conexión con Jira."""
+    """Verify the connection with Jira."""
     try:
         async with httpx.AsyncClient(timeout=20.0) as client:
             response = await client.get(
@@ -21,17 +21,13 @@ async def check_jira_connection() -> bool:
 
 
 async def get_new_issues() -> list[JiraIssue]:
-    """
-    Obtiene tickets nuevos creados en los últimos 3 minutos.
-    """
+    """Fetch new tickets created in the last 3 minutes."""
     jql = f'project = {JIRA_PROJECT_KEY} AND created >= "-3m" ORDER BY created DESC'
     return await _fetch_issues(jql)
 
 
 async def get_updated_issues() -> list[JiraIssue]:
-    """
-    Obtiene tickets actualizados en los últimos 3 minutos (limitado a últimos 5 días).
-    """
+    """Fetch tickets updated in the last 3 minutes (limited to the last 5 days)."""
     jql = (
         f'project = {JIRA_PROJECT_KEY} AND updated >= "-3m" AND created >= "-5d" '
         'AND status IN ("Impact Estimated","QUARANTINE","Resolution In Progress","Routing","Waiting For Customer") '
@@ -88,8 +84,8 @@ async def _fetch_issues(jql: str) -> list[JiraIssue]:
                 if not next_page_token:
                     break
 
-        print(f"Issues devueltos por Jira: {issues_out}")
+        print(f"Issues returned by Jira: {issues_out}")
     except Exception as e:
-        print(f"Error al consultar Jira (search/jql): {e}")
+        print(f"Error querying Jira (search/jql): {e}")
 
     return issues_out

--- a/app/main.py
+++ b/app/main.py
@@ -11,7 +11,7 @@ from .state_manager import StateManager
 
 app = FastAPI(
     title="Jira2Notion Sync API",
-    description="API para sincronización de tickets entre Jira y Notion",
+    description="API for synchronizing tickets between Jira and Notion",
     version="1.0.0"
 )
 
@@ -31,31 +31,31 @@ scheduler: AsyncIOScheduler = None
 
 @app.get("/")
 async def read_root() -> Dict[str, str]:
-    """Endpoint básico para verificar el estado del servicio"""
+    """Basic endpoint to check service status."""
     return {"message": "Jira2Notion integration is running!"}
 
 
 @app.post("/check-updated-issues")
 async def check_updated_issues() -> JSONResponse:
     """
-    Endpoint para verificar y procesar issues actualizados en Jira.
-    Se utiliza la función que ya realiza la verificación de duplicados mediante
-    la lógica de 'create_or_update_notion_page'.
+    Endpoint to verify and process updated issues in Jira.
+    Uses the function that already performs duplicate verification through
+    the 'create_or_update_notion_page' logic.
     """
     try:
         last_key = state.get_last_key()
-        logger.info(f"Último issue procesado: {last_key}")
+        logger.info(f"Last processed issue: {last_key}")
 
         result = await process_updated_issues(last_key)
 
         if "issue_key" in result:
             state.update_last_key(result["issue_key"])
-            logger.info(f"Nuevo último issue procesado: {result['issue_key']}")
+            logger.info(f"New last processed issue: {result['issue_key']}")
 
         return JSONResponse(content=result)
 
     except Exception as e:
-        logger.error(f"Error en /check-updated-issues: {e}", exc_info=True)
+        logger.error(f"Error in /check-updated-issues: {e}", exc_info=True)
         raise HTTPException(
             status_code=500, detail=f"Internal server error: {str(e)}"
         )
@@ -64,24 +64,24 @@ async def check_updated_issues() -> JSONResponse:
 @app.post("/check-new-issues")
 async def check_new_issues() -> JSONResponse:
     """
-    Endpoint para verificar y procesar nuevos issues en Jira.
-    Se utiliza la función que, a través de 'create_or_update_notion_page',
-    evita crear páginas duplicadas en Notion.
+    Endpoint to verify and process new issues in Jira.
+    It uses the function that, through 'create_or_update_notion_page',
+    avoids creating duplicate pages in Notion.
     """
     try:
         last_key = state.get_last_key()
-        logger.info(f"Último issue procesado: {last_key}")
+        logger.info(f"Last processed issue: {last_key}")
 
         result = await process_new_issues(last_key)
 
         if "issue_key" in result:
             state.update_last_key(result["issue_key"])
-            logger.info(f"Nuevo último issue procesado: {result['issue_key']}")
+            logger.info(f"New last processed issue: {result['issue_key']}")
 
         return JSONResponse(content=result)
 
     except Exception as e:
-        logger.error(f"Error en /check-new-issues: {e}", exc_info=True)
+        logger.error(f"Error in /check-new-issues: {e}", exc_info=True)
         raise HTTPException(
             status_code=500, detail=f"Internal server error: {str(e)}"
         )
@@ -90,9 +90,9 @@ async def check_new_issues() -> JSONResponse:
 @app.get("/status")
 async def service_status() -> Dict[str, Any]:
     """
-    Endpoint de estado del servicio.
-    Reporta la conexión con Jira y Notion, el último issue procesado y
-    el próximo tiempo de ejecución de la tarea periódica.
+    Service status endpoint.
+    Reports the connection with Jira and Notion, the last processed issue,
+    and the next scheduled time for the periodic task.
     """
     try:
         from .jira_client import check_jira_connection
@@ -110,7 +110,7 @@ async def service_status() -> Dict[str, Any]:
             "next_run": next_run,
         }
     except Exception as e:
-        logger.error(f"Error en /status: {e}", exc_info=True)
+        logger.error(f"Error in /status: {e}", exc_info=True)
         raise HTTPException(
             status_code=500, detail=f"Error checking service status: {str(e)}"
         )
@@ -118,7 +118,7 @@ async def service_status() -> Dict[str, Any]:
 
 @app.on_event("startup")
 async def startup_event():
-    """Configuración inicial al iniciar la aplicación"""
+    """Initial configuration when starting the application"""
     global scheduler
 
     scheduler = AsyncIOScheduler()
@@ -134,28 +134,28 @@ async def startup_event():
     )
     scheduler.start()
 
-    logger.info("Servicio iniciado correctamente")
-    logger.info(f"Intervalo de verificación: {settings.check_interval} segundos")
-    logger.info(f"Último issue procesado: {state.get_last_key()}")
+    logger.info("Service started successfully")
+    logger.info(f"Check interval: {settings.check_interval} seconds")
+    logger.info(f"Last processed issue: {state.get_last_key()}")
 
 
 @app.on_event("shutdown")
 async def shutdown_event():
-    """Manejo del cierre de la aplicación"""
+    """Handle application shutdown"""
     global scheduler
     if scheduler:
         scheduler.shutdown()
-    logger.info("Servicio detenido correctamente")
+    logger.info("Service stopped successfully")
 
 from .issue_processor import sync_all_user_issues
 
 @app.post("/sync-user-issues")
 async def sync_user_issues():
     """
-    Sincroniza todos los tickets asignados al usuario configurado en Jira,
-    con la base de datos de Notion:
-    - Crea nuevas páginas si no existen.
-    - Actualiza estado a 'Inicial' si ya existen.
+    Synchronize all tickets assigned to the configured Jira user
+    with the Notion database:
+    - Create new pages if they do not exist.
+    - Update status to 'Initial' if they already exist.
     """
     return await sync_all_user_issues()
 

--- a/app/notion_client.py
+++ b/app/notion_client.py
@@ -15,8 +15,8 @@ notion = AsyncClient(auth=NOTION_API_KEY)
 
 async def check_notion_connection() -> bool:
     """
-    Verifica la conexión con la API de Notion.
-    Retorna True si la conexión es exitosa, False si falla.
+    Verify the connection with the Notion API.
+    Returns True if the connection is successful, False otherwise.
     """
     try:
         client = AsyncClient(auth=NOTION_API_KEY)
@@ -27,15 +27,13 @@ async def check_notion_connection() -> bool:
             return True
         return False
     except Exception as e:
-        logging.error(f"Error en la conexión con Notion: {e}")
+        logging.error(f"Error connecting to Notion: {e}")
         return False
 
 
 
 def parse_jira_description(description):
-    """
-    Parsea la descripción del ticket de Jira para convertirla en un texto formateado.
-    """
+    """Parse the Jira ticket description into formatted text."""
     if not description:
         return ""
     
@@ -68,7 +66,7 @@ def parse_jira_description(description):
 
 async def find_notion_page_by_ticket(ticket_key: str) -> dict:
     """
-    Consulta Notion para buscar una página cuyo campo "Jira Issue Key" coincida con el ticket_key.
+    Query Notion to find a page whose "Jira Issue Key" field matches the ticket_key.
     """
     try:
         query = {
@@ -84,17 +82,15 @@ async def find_notion_page_by_ticket(ticket_key: str) -> dict:
         if results:
             return results[0]
     except Exception as e:
-        logger.error(f"Error buscando página en Notion para ticket {ticket_key}: {e}")
+        logger.error(f"Error searching Notion page for ticket {ticket_key}: {e}")
     return None
 
 
 async def create_notion_page(issue: JiraIssue):
-    """
-    Crea una nueva página en Notion usando la información del issue.
-    """
+    """Create a new page in Notion using the issue information."""
     try:
-        logger.info(f"Creando página en Notion para el issue: {issue.key}")
-        reporter_name = issue.reporter.get("displayName", "Desconocido") if issue.reporter else "Desconocido"
+        logger.info(f"Creating Notion page for issue: {issue.key}")
+        reporter_name = issue.reporter.get("displayName", "Unknown") if issue.reporter else "Unknown"
         key_content = issue.key if issue.key else ""
         description_rest_content = parse_jira_description(issue.description_rest) if issue.description_rest else ""
         description_adv_content = parse_jira_description(issue.description_adv) if issue.description_adv else ""
@@ -112,7 +108,7 @@ async def create_notion_page(issue: JiraIssue):
                 "type": "heading_1",
                 "heading_1": {
                     "rich_text": [
-                        {"type": "text", "text": {"content": "Puntos Críticos para Gestión de Tickets"}}
+                        {"type": "text", "text": {"content": "Critical Points for Ticket Management"}}
                     ]
                 }
             },
@@ -121,7 +117,7 @@ async def create_notion_page(issue: JiraIssue):
                 "type": "toggle",
                 "toggle": {
                     "rich_text": [
-                        {"type": "text", "text": {"content": "Cierre de Tickets"}}
+                        {"type": "text", "text": {"content": "Ticket Closure"}}
                     ],
                     "children": [
                         {
@@ -131,7 +127,7 @@ async def create_notion_page(issue: JiraIssue):
                                 "rich_text": [
                                     {
                                         "type": "text",
-                                        "text": {"content": "Tipificación y Etiquetas: Asegurarse de incluir la tipificación y las etiquetas adecuadas en todos los tickets cerrados."}
+                                        "text": {"content": "Categorization and Tags: Ensure the correct categorization and tags are included on all closed tickets."}
                                     }
                                 ],
                                 "checked": False
@@ -155,7 +151,7 @@ async def create_notion_page(issue: JiraIssue):
                                 "rich_text": [
                                     {
                                         "type": "text",
-                                        "text": {"content": "Tipo de Ticket Correcto: Verificar que los tickets de otros Issue Types no sean cerrados como *Issue Type Rest*."}
+                                        "text": {"content": "Correct Ticket Type: Verify that tickets from other Issue Types are not closed as *Issue Type Rest*."}
                                     }
                                 ],
                                 "checked": False
@@ -179,7 +175,7 @@ async def create_notion_page(issue: JiraIssue):
                                 "rich_text": [
                                     {
                                         "type": "text",
-                                        "text": {"content": "Ticket Linkeado: Confirmar que cada *Production Bug* tenga un ticket vinculado."}
+                                        "text": {"content": "Linked Ticket: Ensure each *Production Bug* has a linked ticket."}
                                     }
                                 ],
                                 "checked": False
@@ -192,7 +188,7 @@ async def create_notion_page(issue: JiraIssue):
                                 "rich_text": [
                                     {
                                         "type": "text",
-                                        "text": {"content": "Duplicados: Duplicados de escalados deben quedar como *Production Bug* y finalizados."}
+                                        "text": {"content": "Duplicates: Escalated duplicates should remain as *Production Bug* and be completed."}
                                     }
                                 ],
                                 "checked": False
@@ -205,7 +201,7 @@ async def create_notion_page(issue: JiraIssue):
                                 "rich_text": [
                                     {
                                         "type": "text",
-                                        "text": {"content": "Sin componente: No asignar componentes a duplicados cerrados."}
+                                        "text": {"content": "No Component: Do not assign components to closed duplicates."}
                                     }
                                 ],
                                 "checked": False
@@ -218,7 +214,7 @@ async def create_notion_page(issue: JiraIssue):
                                 "rich_text": [
                                     {
                                         "type": "text",
-                                        "text": {"content": "Consistencia: Asegurar que el principal y el duplicado queden correctamente tipificados."}
+                                        "text": {"content": "Consistency: Ensure the main issue and the duplicate are categorized correctly."}
                                     }
                                 ],
                                 "checked": False
@@ -232,7 +228,7 @@ async def create_notion_page(issue: JiraIssue):
                 "type": "toggle",
                 "toggle": {
                     "rich_text": [
-                        {"type": "text", "text": {"content": "Escalados"}}
+                        {"type": "text", "text": {"content": "Escalations"}}
                     ],
                     "children": [
                         {
@@ -242,7 +238,7 @@ async def create_notion_page(issue: JiraIssue):
                                 "rich_text": [
                                     {
                                         "type": "text",
-                                        "text": {"content": "Assignee: Asegurar que siempre sea el EL correspondiente de cada equipo."}
+                                        "text": {"content": "Assignee: Ensure it is always the corresponding EL for each team."}
                                     }
                                 ],
                                 "checked": False
@@ -255,7 +251,7 @@ async def create_notion_page(issue: JiraIssue):
                                 "rich_text": [
                                     {
                                         "type": "text",
-                                        "text": {"content": "Componentes y Datos Obligatorios: Confirmar que se incluyan todos los datos y componentes necesarios."}
+                                        "text": {"content": "Required Components and Data: Confirm that all necessary data and components are included."}
                                     }
                                 ],
                                 "checked": False
@@ -268,7 +264,7 @@ async def create_notion_page(issue: JiraIssue):
                                 "rich_text": [
                                     {
                                         "type": "text",
-                                        "text": {"content": "ETA IM: Asegurarse de que cada caso tenga el ETA IM del RSUP o ADVS antes de estar en estado *Escalated*."}
+                                        "text": {"content": "ETA IM: Ensure each case has the RSUP or ADVS ETA IM before being in *Escalated* status."}
                                     }
                                 ],
                                 "checked": False
@@ -281,7 +277,7 @@ async def create_notion_page(issue: JiraIssue):
                                 "rich_text": [
                                     {
                                         "type": "text",
-                                        "text": {"content": "Campos de Escalado: Completar todos los campos obligatorios."}
+                                        "text": {"content": "Escalation Fields: Complete all required fields."}
                                     }
                                 ],
                                 "checked": False
@@ -294,7 +290,7 @@ async def create_notion_page(issue: JiraIssue):
                                 "rich_text": [
                                     {
                                         "type": "text",
-                                        "text": {"content": "Documentación Completa: Registrar el PM correspondiente, dejar evidencia detallada del caso en la descripción, y asegurar que los casos gestionados por el NOC sean documentados por quien los llevó."}
+                                        "text": {"content": "Complete Documentation: Record the corresponding PM, provide detailed case evidence in the description, and ensure cases handled by the NOC are documented by whoever handled them."}
                                     }
                                 ],
                                 "checked": False
@@ -313,7 +309,7 @@ async def create_notion_page(issue: JiraIssue):
                 "type": "heading_2",
                 "heading_2": {
                     "rich_text": [
-                        {"type": "text", "text": {"content": "Notas"}}
+                        {"type": "text", "text": {"content": "Notes"}}
                     ]
                 }
             },
@@ -322,7 +318,7 @@ async def create_notion_page(issue: JiraIssue):
                 "type": "paragraph",
                 "paragraph": {
                     "rich_text": [
-                        {"type": "text", "text": {"content": "Revisar que todo el backlog esté al día antes del **31/01**."}}
+                        {"type": "text", "text": {"content": "Make sure the entire backlog is up to date before **01/31**."}}
                     ]
                 }
             },
@@ -331,13 +327,13 @@ async def create_notion_page(issue: JiraIssue):
                 "type": "paragraph",
                 "paragraph": {
                     "rich_text": [
-                        {"type": "text", "text": {"content": "Verificar que los tickets creados en 2025 estén correctamente tipificados."}}
+                        {"type": "text", "text": {"content": "Verify that tickets created in 2025 are properly categorized."}}
                     ]
                 }
             }
         ]
-        rest_chunks = split_text("Descripción Rest:\n" + description_rest_content)
-        adv_chunks = split_text("Descripción Revenue:\n" + description_adv_content)
+        rest_chunks = split_text("Rest Description:\n" + description_rest_content)
+        adv_chunks = split_text("Revenue Description:\n" + description_adv_content)
         rest_blocks = [
             {
                 "object": "block",
@@ -372,16 +368,16 @@ async def create_notion_page(issue: JiraIssue):
                 "Reporter": {
                     "rich_text": [{"type": "text", "text": {"content": reporter_name}}]
                 },
-                "Fecha de creación": {
+                "Creation Date": {
                     "date": {"start": created_date_iso}
                 },
                 "Tags": {
-                    "multi_select": [{"name": "trabajo"}]
+                    "multi_select": [{"name": "work"}]
                 },
-                "Asignación": {
+                "Assignment": {
                     "people": [{"id": "564716e3-359a-48a0-b3ea-e54c74902573"}]
                 },
-                "Verificado": {
+                "Verified": {
                     "checkbox": False
                 }
             },
@@ -415,7 +411,7 @@ async def create_notion_page(issue: JiraIssue):
                             {
                                 "type": "text",
                                 "text": {
-                                    "content": "Accionables"
+                                    "content": "Action Items"
                                 },
                                 "annotations": {
                                     "bold": True,
@@ -460,20 +456,18 @@ async def create_notion_page(issue: JiraIssue):
         }
 
         response = await notion.pages.create(**payload)
-        logger.info(f"Página creada exitosamente en Notion para el issue: {issue.key}")
+        logger.info(f"Page successfully created in Notion for issue: {issue.key}")
         return response
     except Exception as e:
-        logger.error(f"Error al crear la página en Notion para el issue {issue.key}: {e}")
+        logger.error(f"Error creating Notion page for issue {issue.key}: {e}")
         raise
 
 
 async def update_notion_page(page_id: str, issue: JiraIssue):
-    """
-    Actualiza la página existente en Notion con la información actual del issue.
-    """
+    """Update the existing Notion page with the current issue information."""
     try:
         issue_key = getattr(issue, "key", "UNKNOWN")
-        logger.info(f"Actualizando página en Notion para el issue: {issue_key}")
+        logger.info(f"Updating Notion page for issue: {issue_key}")
 
         summary = getattr(issue, "summary", "")
         description_content = parse_jira_description(getattr(issue, "description", "")) or ""
@@ -491,56 +485,56 @@ async def update_notion_page(page_id: str, issue: JiraIssue):
         }
 
         response = await notion.pages.update(page_id=page_id, **payload)
-        logger.info(f"Página actualizada exitosamente en Notion para el issue: {issue_key}")
+        logger.info(f"Page successfully updated in Notion for issue: {issue_key}")
         return response
 
     except Exception as e:
         issue_key = getattr(issue, "key", "UNKNOWN")
-        logger.error(f"Error al actualizar la página en Notion para el issue {issue_key}: {e}")
+        logger.error(f"Error updating Notion page for issue {issue_key}: {e}")
         raise
 
 async def create_or_update_notion_page(issue: JiraIssue):
     """
-    Función que primero busca si ya existe una página en Notion para el issue.
-    Si existe, se actualiza; de lo contrario, se crea una nueva.
+    Function that first checks if a Notion page already exists for the issue.
+    If it exists, it is updated; otherwise, a new one is created.
     """
     try:
         existing_page = await find_notion_page_by_ticket(issue.key)
         if existing_page:
             page_id = existing_page.get("id")
-            logger.info(f"Página ya existe para el issue {issue.key}, se procederá a actualizarla.")
+            logger.info(f"Page already exists for issue {issue.key}, proceeding to update.")
             return await update_notion_page(page_id, issue)
         else:
-            logger.info(f"No se encontró página existente para el issue {issue.key}, se creará una nueva.")
+            logger.info(f"No existing page found for issue {issue.key}, creating a new one.")
             return await create_notion_page(issue)
     except Exception as e:
-        logger.error(f"Error en create_or_update_notion_page para el issue {issue.key}: {e}")
+        logger.error(f"Error in create_or_update_notion_page for issue {issue.key}: {e}")
         raise
 
-async def set_notion_verificado(page: dict, verificado) -> dict:
+async def set_notion_verified(page: dict, verified) -> dict:
     """
-    Actualiza el campo tipo checkbox 'Verificado' de la página en Notion.
-    El valor puede ser booleano o un string convertible (como "True", "Inicial", etc.).
+    Update the checkbox field 'Verified' on the Notion page.
+    The value can be a boolean or a convertible string (like "True", "Initial", etc.).
     """
     try:
-        if isinstance(verificado, str):
-            verificado_bool = verificado.strip().lower() == "true"
+        if isinstance(verified, str):
+            verified_bool = verified.strip().lower() == "true"
         else:
-            verificado_bool = bool(verificado)
+            verified_bool = bool(verified)
 
         page_id = page["id"]
         payload = {
             "properties": {
-                "Verificado": {
-                    "checkbox": verificado_bool
+                "Verified": {
+                    "checkbox": verified_bool
                 }
             }
         }
         response = await notion.pages.update(page_id=page_id, **payload)
-        logger.info(f"Campo 'Verificado' actualizado a {verificado_bool} en página {page_id}")
+        logger.info(f"Field 'Verified' updated to {verified_bool} on page {page_id}")
         return response
     except Exception as e:
-        logger.error(f"Error al actualizar campo 'Verificado' en Notion para la página {page.get('id', 'desconocida')}: {e}")
+        logger.error(f"Error updating 'Verified' field in Notion for page {page.get('id', 'unknown')}: {e}")
         raise
 
 

--- a/app/state_manager.py
+++ b/app/state_manager.py
@@ -7,10 +7,10 @@ class StateManager:
         self.table = self.db.table('last_processed')
         
     def get_last_key(self) -> Optional[str]:
-        """Obtiene el último issue procesado"""
+        """Retrieve the last processed issue key."""
         doc = self.table.get(doc_id=1)
         return doc['value'] if doc else None
-        
+
     def update_last_key(self, key: str) -> None:
-        """Actualiza el último issue procesado"""
+        """Update the last processed issue key."""
         self.table.upsert({'value': key}, doc_ids=[1])


### PR DESCRIPTION
## Summary
- Convert Spanish comments, log messages, and strings to English across the codebase for consistency.
- Standardize property and field names such as "Creation Date", "Assignment", and "Verified".
- Rename helper to `set_notion_verified` and update references.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b51914e168833395e2be2f1b574f28