### PR TITLE
feat: add configurable Jira to Notion field mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,13 @@ environment):
   `LOG_FILE`             Log file path                    `app.log`
   ----------------------------------------------------------------------------------
 
+### Field mapping
+
+Jira and Notion field names are linked in `app/field_map.yaml`.
+Each entry defines a `jira_field: notion_property` pair used by the
+Jira client to request fields and by the Notion client to build page
+properties. Adjust this file to match your workspace.
+
 ------------------------------------------------------------------------
 
 ## 🚀 Quick Start

--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ environment):
 Jira and Notion field names are linked in `app/field_map.yaml`.
 Each entry defines a `jira_field: notion_property` pair used by the
 Jira client to request fields and by the Notion client to build page
-properties. Adjust this file to match your workspace.
+properties. Adjust this file to match your workspace. Any Notion
+properties that do not exist in the target database are ignored during
+page creation or updates to avoid API errors.
 
 ------------------------------------------------------------------------
 

--- a/app/field_map.yaml
+++ b/app/field_map.yaml
@@ -1,0 +1,8 @@
+summary: Name
+key: Jira Issue Key
+reporter: Reporter
+created: Fecha de creación
+status: Status
+assignee: Assignee
+description: Description
+customfield_12286: Additional Info

--- a/app/notion_client.py
+++ b/app/notion_client.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone, timedelta
 import pytz
 import yaml
 from notion_client import AsyncClient
+from typing import Optional
 
 from .models import JiraIssue
 
@@ -23,7 +24,7 @@ with FIELD_MAP_PATH.open("r", encoding="utf-8") as f:
 notion = AsyncClient(auth=NOTION_API_KEY)
 
 # Cache for Notion database property names
-_NOTION_PROPERTIES: set[str] | None = None
+_NOTION_PROPERTIES: Optional[set[str]] = None
 
 
 async def get_database_properties() -> set[str]:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ requests==2.32.3
 pytz==2025.1
 tinydb==4.8.2
 apscheduler==3.11.0
+PyYAML==6.0.1


### PR DESCRIPTION
## Summary
- load Jira-to-Notion field mapping from `app/field_map.yaml`
- build Jira field list and Notion page properties dynamically
- document field mapping configuration

## Testing
- `python -m py_compile app/jira_client.py app/notion_client.py`
- `pip install -r requirements.txt pytest` *(failed: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68b53232eebc8333b4109237856e98c7