### PR TITLE
Replace eval with json.loads for parsing Jira descriptions

### DIFF
--- a/app/notion_client.py
+++ b/app/notion_client.py
@@ -1,5 +1,6 @@
 import os
 import logging
+import json
 from pathlib import Path
 from datetime import datetime, timezone, timedelta
 
@@ -64,7 +65,7 @@ def parse_jira_description(description):
         return ""
     
     try:
-        description_json = description if isinstance(description, dict) else eval(description)
+        description_json = description if isinstance(description, dict) else json.loads(description)
         content = description_json.get('content', [])
         formatted_text = ""
 
@@ -85,6 +86,9 @@ def parse_jira_description(description):
                         formatted_text += "\n"
 
         return formatted_text.strip()
+    except json.JSONDecodeError as e:
+        logger.error(f"Error parsing Jira description: {e}")
+        return description
     except Exception as e:
         logger.error(f"Error parsing Jira description: {e}")
         return description


### PR DESCRIPTION
## Summary
- parse Jira descriptions using `json.loads` instead of `eval`
- log malformed description errors via `json.JSONDecodeError`

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b54312a4948333a5b300790d195bd2