### PR TITLE
refactor: use TypedDict for JiraIssue

### DIFF
--- a/app/filters.py
+++ b/app/filters.py
@@ -16,8 +16,8 @@ def filter_issues_by_assignee(issues: List[JiraIssue], assignee: str) -> List[Ji
 
     filtered_issues = []
     for issue in issues:
-        email = (issue.emailAddress or "").lower()
-        name = (issue.displayName or "").lower()
+        email = (issue.get("emailAddress") or "").lower()
+        name = (issue.get("displayName") or "").lower()
         if "@" in assignee_lower:
             if email == assignee_lower:
                 filtered_issues.append(issue)

--- a/app/issue_processor.py
+++ b/app/issue_processor.py
@@ -21,7 +21,7 @@ async def process_updated_issues(last_key):
     last_processed_issue = None
 
     for issue in issues:
-        issue_key = issue.key
+        issue_key = issue.get("key")
         logger.info(f"Processing updated issue: {issue_key}")
         await create_or_update_notion_page(issue)
         last_processed_issue = issue_key
@@ -39,14 +39,14 @@ async def process_new_issues(last_processed_issue_key):
             
             if filtered_issues:
                 latest_issue = filtered_issues[0]
-                if latest_issue.key != last_processed_issue_key:
-                    logger.info(f"New issue detected: {latest_issue.key}")
-                    
+                if latest_issue.get("key") != last_processed_issue_key:
+                    logger.info(f"New issue detected: {latest_issue.get('key')}")
+
                     await create_or_update_notion_page(latest_issue)
-                    last_processed_issue_key = latest_issue.key
-                    
-                    logger.info(f"Notion page created or updated for issue: {latest_issue.key}")
-                    return {"message": "New issue processed", "issue_key": latest_issue.key}
+                    last_processed_issue_key = latest_issue.get("key")
+
+                    logger.info(f"Notion page created or updated for issue: {latest_issue.get('key')}")
+                    return {"message": "New issue processed", "issue_key": latest_issue.get("key")}
                 else:
                     logger.info(f"No new issues assigned to {settings.jira_assignee}")
                     return {"message": "No new issues"}
@@ -68,11 +68,11 @@ async def periodic_task(last_processed_issue_key, manual_run: bool = False):
 
         if filtered_issues:
             latest_issue = filtered_issues[0]
-            if latest_issue.key != last_processed_issue_key:
-                logger.info(f"New issue or update detected: {latest_issue.key}")
+            if latest_issue.get("key") != last_processed_issue_key:
+                logger.info(f"New issue or update detected: {latest_issue.get('key')}")
 
                 await create_or_update_notion_page(latest_issue)
-                last_processed_issue_key = latest_issue.key
+                last_processed_issue_key = latest_issue.get("key")
             else:
                 logger.info("No new issues or updates.")
         else:
@@ -104,7 +104,7 @@ async def sync_all_user_issues():
         processed_issues = []
 
         for issue in issues:
-            issue_key = issue.key
+            issue_key = issue.get("key")
             logger.info(f"Synchronizing issue: {issue_key}")
 
             existing_page = await find_notion_page_by_ticket(issue_key)

--- a/app/models.py
+++ b/app/models.py
@@ -1,13 +1,25 @@
-from typing import Optional
-from pydantic import BaseModel
+"""Data models used throughout the application."""
 
-class JiraIssue(BaseModel):
+from typing import Any, TypedDict
+
+
+class JiraIssue(TypedDict, total=False):
+    """Minimal representation of a Jira issue returned by the API.
+
+    All fields are optional to mirror the behaviour of the Jira API where any
+    field may be missing depending on the JQL query.  When accessing these
+    fields elsewhere in the code base, ``dict.get`` should be used to avoid
+    ``KeyError`` exceptions.
+    """
+
     key: str
     summary: str
     description_rest: str
     status: str
     created: str
-    reporter: Optional[dict]
-    displayName: Optional[str]
-    emailAddress: Optional[str]
-    description_adv: Optional[dict]
+    reporter: dict[str, Any]
+    assignee: dict[str, Any]
+    displayName: str
+    emailAddress: str
+    description_adv: Any
+


### PR DESCRIPTION
## Summary
- represent Jira issues as TypedDict instead of pydantic model
- update Jira client to produce JiraIssue dicts
- adjust processors and Notion integration to use dict-style access

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5476f0d6c83338f4707f1330e67c0