### PR TITLE
feat: allow dynamic issue fields

### DIFF
--- a/app/issue_processor.py
+++ b/app/issue_processor.py
@@ -1,10 +1,15 @@
 import asyncio
 from .jira_client import get_new_issues, get_updated_issues
-from .notion_client import create_or_update_notion_page, create_notion_page, update_notion_page
+from .notion_client import (
+    create_or_update_notion_page,
+    create_notion_page,
+    update_notion_page,
+)
 from .filters import filter_issues_by_assignee
 from .logger_config import setup_logger
 from .config import settings
 from .notion_client import find_notion_page_by_ticket, set_notion_verified
+from .models import JiraIssue
 from fastapi import HTTPException
 
 
@@ -12,7 +17,7 @@ logger = setup_logger()
 
 async def process_updated_issues(last_key):
     """Process issues updated since the last recorded issue."""
-    issues = await get_updated_issues()
+    issues: list[JiraIssue] = await get_updated_issues()
 
     if not issues:
         logger.info("No new issues or updates.")
@@ -21,6 +26,9 @@ async def process_updated_issues(last_key):
     last_processed_issue = None
 
     for issue in issues:
+        if not issue.get("key") or not issue.get("summary"):
+            logger.warning("Skipping issue with missing key or summary")
+            continue
         issue_key = issue.get("key")
         logger.info(f"Processing updated issue: {issue_key}")
         await create_or_update_notion_page(issue)
@@ -31,7 +39,7 @@ async def process_updated_issues(last_key):
 async def process_new_issues(last_processed_issue_key):
     try:
         logger.info("Starting check for new issues in Jira")
-        issues = await get_new_issues()
+        issues: list[JiraIssue] = await get_new_issues()
         
         if issues:
             logger.info(f"Retrieved {len(issues)} new issues from Jira")
@@ -45,8 +53,13 @@ async def process_new_issues(last_processed_issue_key):
                     await create_or_update_notion_page(latest_issue)
                     last_processed_issue_key = latest_issue.get("key")
 
-                    logger.info(f"Notion page created or updated for issue: {latest_issue.get('key')}")
-                    return {"message": "New issue processed", "issue_key": latest_issue.get("key")}
+                    logger.info(
+                        f"Notion page created or updated for issue: {latest_issue.get('key')}"
+                    )
+                    return {
+                        "message": "New issue processed",
+                        "issue_key": latest_issue.get("key"),
+                    }
                 else:
                     logger.info(f"No new issues assigned to {settings.jira_assignee}")
                     return {"message": "No new issues"}
@@ -62,14 +75,16 @@ async def process_new_issues(last_processed_issue_key):
 
 async def periodic_task(last_processed_issue_key, manual_run: bool = False):
     try:
-        issues = await get_updated_issues()
+        issues: list[JiraIssue] = await get_updated_issues()
         logger.info(f"Fetched {len(issues)} updated issues")
         filtered_issues = filter_issues_by_assignee(issues, settings.jira_assignee)
 
         if filtered_issues:
             latest_issue = filtered_issues[0]
             if latest_issue.get("key") != last_processed_issue_key:
-                logger.info(f"New issue or update detected: {latest_issue.get('key')}")
+                logger.info(
+                    f"New issue or update detected: {latest_issue.get('key')}"
+                )
 
                 await create_or_update_notion_page(latest_issue)
                 last_processed_issue_key = latest_issue.get("key")
@@ -96,7 +111,7 @@ async def sync_all_user_issues():
             'ORDER BY updated DESC'
         )
         from .jira_client import _fetch_issues
-        issues = await _fetch_issues(jql)
+        issues: list[JiraIssue] = await _fetch_issues(jql)
 
         if not issues:
             return {"message": "No issues assigned to this user."}
@@ -104,17 +119,24 @@ async def sync_all_user_issues():
         processed_issues = []
 
         for issue in issues:
+            if not issue.get("key") or not issue.get("summary"):
+                logger.warning("Skipping issue with missing key or summary")
+                continue
             issue_key = issue.get("key")
             logger.info(f"Synchronizing issue: {issue_key}")
 
             existing_page = await find_notion_page_by_ticket(issue_key)
 
             if existing_page:
-                logger.info(f"Updating status to 'Initial' for the existing page of {issue_key}")
+                logger.info(
+                    f"Updating status to 'Initial' for the existing page of {issue_key}"
+                )
                 await set_notion_verified(existing_page, False)
                 await update_notion_page(existing_page["id"], issue)
             else:
-                logger.info(f"Creating new Notion page with status 'Initial' for {issue_key}")
+                logger.info(
+                    f"Creating new Notion page with status 'Initial' for {issue_key}"
+                )
                 await create_notion_page(issue)
 
             processed_issues.append(issue_key)

--- a/app/models.py
+++ b/app/models.py
@@ -1,25 +1,26 @@
 """Data models used throughout the application."""
 
-from typing import Any, TypedDict
+from typing import Any
+
+from pydantic import BaseModel, Extra, validator
 
 
-class JiraIssue(TypedDict, total=False):
-    """Minimal representation of a Jira issue returned by the API.
-
-    All fields are optional to mirror the behaviour of the Jira API where any
-    field may be missing depending on the JQL query.  When accessing these
-    fields elsewhere in the code base, ``dict.get`` should be used to avoid
-    ``KeyError`` exceptions.
-    """
+class JiraIssue(BaseModel):
+    """Representation of a Jira issue with dynamic fields allowed."""
 
     key: str
     summary: str
-    description_rest: str
-    status: str
-    created: str
-    reporter: dict[str, Any]
-    assignee: dict[str, Any]
-    displayName: str
-    emailAddress: str
-    description_adv: Any
+
+    class Config:
+        extra = Extra.allow
+
+    def get(self, item: str, default: Any = None) -> Any:
+        """Provide dict-like access to dynamically added attributes."""
+        return getattr(self, item, default)
+
+    @validator("key", "summary")
+    def _not_empty(cls, value: str) -> str:  # pylint: disable=no-self-argument
+        if not value:
+            raise ValueError("field must not be empty")
+        return value
 

--- a/app/notion_client.py
+++ b/app/notion_client.py
@@ -132,11 +132,6 @@ async def build_properties(
             )
             continue
         value = issue.get(jira_field)
-        if value is None:
-            if jira_field == "customfield_12286":
-                value = issue.get("description_rest")
-            elif jira_field == "description":
-                value = issue.get("description_adv")
         if jira_field == "summary":
             properties[notion_prop] = {
                 "title": [{"type": "text", "text": {"content": value or ""}}]
@@ -193,8 +188,16 @@ async def create_notion_page(issue: JiraIssue):
     try:
         logger.info(f"Creating Notion page for issue: {issue.get('key')}")
         key_content = issue.get("key") or ""
-        description_rest_content = parse_jira_description(issue.get("description_rest")) if issue.get("description_rest") else ""
-        description_adv_content = parse_jira_description(issue.get("description_adv")) if issue.get("description_adv") else ""
+        customfield_content = (
+            parse_jira_description(issue.get("customfield_12286"))
+            if issue.get("customfield_12286")
+            else ""
+        )
+        description_content = (
+            parse_jira_description(issue.get("description"))
+            if issue.get("description")
+            else ""
+        )
         markdown_content = [
             {
                 "object": "block",
@@ -425,8 +428,8 @@ async def create_notion_page(issue: JiraIssue):
                 }
             }
         ]
-        rest_chunks = split_text("Rest Description:\n" + description_rest_content)
-        adv_chunks = split_text("Revenue Description:\n" + description_adv_content)
+        rest_chunks = split_text("Rest Description:\n" + customfield_content)
+        adv_chunks = split_text("Revenue Description:\n" + description_content)
         rest_blocks = [
             {
                 "object": "block",


### PR DESCRIPTION
## Summary
- replace static JiraIssue model with flexible Pydantic model
- support dynamic fields in Jira fetch and Notion sync
- validate required fields when processing issues

## Testing
- `python -m py_compile app/models.py app/jira_client.py app/notion_client.py app/issue_processor.py`


------
https://chatgpt.com/codex/tasks/task_e_68b54a3bdfb083339c0f64b4cf17a185