### PR TITLE
AIMA-49: Gateway /simulateTicket -> produce ticket.created (Kafka) + metrics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,7 @@ JIRA_DOMAIN=
 NOTION_API_KEY=
 NOTION_DATABASE_ID=
 PROJECTS=[{"key":"PROJ","jql":"assignee = currentUser() AND status IN (\"To Do\", \"In Progress\", \"Impact Estimated\", \"QUARANTINE\", \"Resolution In Progress\", \"Routing\", \"Waiting For Customer\") ORDER BY updated DESC"}]
+DOCKER_NETWORK=aimnet
+KAFKA_BROKER=kafka:9092
+GATEWAY_PORT=8000
+TICKET_TOPIC=ticket.created

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+COPY gateway/requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r /app/requirements.txt
+
+COPY gateway/app /app/app
+
+ENV GATEWAY_PORT=8000 \
+    SERVICE_NAME=gateway
+
+EXPOSE 8000
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--proxy-headers"]

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -1,0 +1,78 @@
+# Gateway Service
+
+The gateway is a FastAPI service that can simulate ticket creation events and publish them into Kafka.
+It also exposes Prometheus metrics for observability.
+
+## Endpoints
+
+- `GET /health` – Simple health probe returning the service status.
+- `GET /metrics` – Prometheus metrics in the text exposition format.
+- `POST /simulateTicket` – Publish a `ticket.created` event to Kafka. The request body is optional; if it is missing the service generates a synthetic payload.
+
+### Request headers
+
+- `Content-Type: application/json` (when sending a custom body).
+- `X-Idempotency-Key` (optional). When present the same key prevents duplicate events. If omitted, the `ticketId` is used as the idempotency key.
+
+### Request body schema
+
+```json
+{
+  "ticketId": "AIMA-49-DEMO",
+  "source": "simulator",
+  "projectKey": "AIMA",
+  "summary": "Cannot log in to JSM",
+  "description": "401 error when using SSO",
+  "reporter": "diego.martinez@rappi.com",
+  "priority": "Medium",
+  "lang": "en",
+  "createdAt": "2024-05-14T16:00:00Z"
+}
+```
+
+All fields are optional; unspecified values are filled with defaults. The service always adds `eventType="ticket.created"` and `version="v1"` before sending the payload to Kafka.
+
+## Running locally with Docker Compose
+
+1. Copy the environment template:
+   ```bash
+   cp .env.example .env
+   ```
+2. Build and start the stack:
+   ```bash
+   docker compose -f infra/docker-compose.yml up -d --build
+   ```
+
+Kafka, Zookeeper, the gateway, and Prometheus will be started on the shared `aimnet` network.
+
+## Smoke tests
+
+```bash
+# Health and metrics
+curl -s http://localhost:8000/health
+curl -s http://localhost:8000/metrics | head
+
+# Send with custom payload and idempotency key
+curl -X POST http://localhost:8000/simulateTicket \
+  -H 'Content-Type: application/json' \
+  -H 'X-Idempotency-Key: demo-001' \
+  -d '{
+    "ticketId": "AIMA-49-DEMO",
+    "summary": "Cannot log in to JSM",
+    "description": "401 error when using SSO",
+    "priority": "High",
+    "reporter": "diego.martinez@rappi.com",
+    "projectKey": "AIMA",
+    "lang": "en"
+  }'
+
+# Send with no body (auto-generated)
+curl -X POST http://localhost:8000/simulateTicket
+
+# Consume from Kafka
+# (press Ctrl+C once a message is shown)
+docker compose -f infra/docker-compose.yml exec kafka bash -lc \
+  'kafka-console-consumer --bootstrap-server localhost:9092 --topic ticket.created --from-beginning --timeout-ms 3000'
+```
+
+Prometheus metrics can be inspected at http://localhost:9090 once the stack is up.

--- a/gateway/app/main.py
+++ b/gateway/app/main.py
@@ -1,0 +1,126 @@
+import json
+import os
+import time
+import uuid
+from typing import Optional
+
+from aiokafka import AIOKafkaProducer
+from fastapi import FastAPI, Header
+from fastapi.responses import PlainTextResponse
+from pydantic import BaseModel, Field
+from prometheus_client import CONTENT_TYPE_LATEST, Counter, Histogram, generate_latest
+
+KAFKA_BROKER = os.getenv("KAFKA_BROKER", "kafka:9092")
+TOPIC = os.getenv("TICKET_TOPIC", "ticket.created")
+SERVICE_NAME = os.getenv("SERVICE_NAME", "gateway")
+
+app = FastAPI(title="AIM Agent Gateway")
+
+# Prometheus metrics
+EVENTS_COUNTER = Counter(
+    "gateway_events_produced_total",
+    "Total number of Kafka events produced by the gateway",
+    ["topic", "result"],
+)
+LATENCY_HISTOGRAM = Histogram(
+    "gateway_kafka_produce_latency_seconds",
+    "Kafka produce latency in seconds",
+    buckets=(0.01, 0.05, 0.1, 0.25, 0.5, 1, 2, 5),
+)
+
+# Simple in-memory idempotency cache (prototype use only)
+SEEN_IDS: set[str] = set()
+MAX_SEEN = 5000
+
+
+class TicketPayload(BaseModel):
+    ticketId: Optional[str] = Field(None, description="Unique ticket identifier")
+    source: str = Field(default="simulator")
+    projectKey: str = Field(default="AIMA")
+    summary: str = Field(default="Example: Menu not loading")
+    description: str = Field(default="User reports a timeout when loading the menu.")
+    reporter: str = Field(default="diego.martinez@rappi.com")
+    priority: str = Field(default="Medium")
+    lang: str = Field(default="en")
+    createdAt: Optional[str] = None  # ISO8601 timestamp
+
+
+producer: Optional[AIOKafkaProducer] = None
+
+
+@app.on_event("startup")
+async def on_startup() -> None:
+    """Initialize Kafka producer on startup."""
+    global producer
+    producer = AIOKafkaProducer(
+        bootstrap_servers=KAFKA_BROKER,
+        value_serializer=lambda value: json.dumps(value).encode("utf-8"),
+        key_serializer=lambda key: key.encode("utf-8"),
+    )
+    await producer.start()
+
+
+@app.on_event("shutdown")
+async def on_shutdown() -> None:
+    """Stop Kafka producer gracefully."""
+    if producer:
+        await producer.stop()
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    """Health check endpoint."""
+    return {"status": "ok", "service": SERVICE_NAME}
+
+
+@app.get("/metrics", response_class=PlainTextResponse)
+def metrics() -> PlainTextResponse:
+    """Expose Prometheus metrics."""
+    return PlainTextResponse(generate_latest(), media_type=CONTENT_TYPE_LATEST)
+
+
+@app.post("/simulateTicket")
+async def simulate_ticket(
+    body: Optional[TicketPayload] = None,
+    x_idempotency_key: Optional[str] = Header(default=None),
+) -> dict[str, object]:
+    """
+    Simulate or create a ticket and publish a 'ticket.created' event to Kafka.
+    Idempotency is handled using the 'X-Idempotency-Key' header or the 'ticketId' field.
+    """
+    now_iso = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    if body is None:
+        body = TicketPayload()
+    if not body.ticketId:
+        body.ticketId = f"AIMA-{uuid.uuid4().hex[:8]}"
+    if not body.createdAt:
+        body.createdAt = now_iso
+
+    idem_key = x_idempotency_key or body.ticketId
+    if idem_key in SEEN_IDS:
+        return {"status": "duplicated", "ticketId": body.ticketId, "topic": TOPIC}
+    if len(SEEN_IDS) > MAX_SEEN:
+        SEEN_IDS.clear()
+    SEEN_IDS.add(idem_key)
+
+    event = body.model_dump()
+    event["eventType"] = "ticket.created"
+    event["version"] = "v1"
+
+    start = time.perf_counter()
+    assert producer is not None, "Kafka producer is not initialized"
+    try:
+        await producer.send_and_wait(TOPIC, key=body.ticketId, value=event)
+        LATENCY_HISTOGRAM.observe(time.perf_counter() - start)
+        EVENTS_COUNTER.labels(topic=TOPIC, result="ok").inc()
+        return {
+            "status": "ok",
+            "ticketId": body.ticketId,
+            "topic": TOPIC,
+            "sentAt": now_iso,
+            "payload": event,
+        }
+    except Exception as exc:  # pylint: disable=broad-except
+        LATENCY_HISTOGRAM.observe(time.perf_counter() - start)
+        EVENTS_COUNTER.labels(topic=TOPIC, result="error").inc()
+        return {"status": "error", "error": str(exc)}

--- a/gateway/requirements.txt
+++ b/gateway/requirements.txt
@@ -1,0 +1,5 @@
+fastapi>=0.118
+uvicorn[standard]>=0.36
+aiokafka>=0.10
+prometheus-client>=0.20
+pydantic>=2.8

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,0 +1,60 @@
+version: "3.9"
+
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.5.0
+    container_name: zookeeper
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    ports:
+      - "2181:2181"
+    networks: ["${DOCKER_NETWORK:-aimnet}"]
+
+  kafka:
+    image: confluentinc/cp-kafka:7.5.0
+    container_name: kafka
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+    networks: ["${DOCKER_NETWORK:-aimnet}"]
+
+  gateway:
+    build:
+      context: ..
+      dockerfile: gateway/Dockerfile
+    container_name: gateway
+    environment:
+      - DOCKER_NETWORK=${DOCKER_NETWORK:-aimnet}
+      - KAFKA_BROKER=${KAFKA_BROKER:-kafka:9092}
+      - GATEWAY_PORT=${GATEWAY_PORT:-8000}
+      - SERVICE_NAME=gateway
+      - TICKET_TOPIC=${TICKET_TOPIC:-ticket.created}
+    depends_on:
+      - kafka
+    networks: ["${DOCKER_NETWORK:-aimnet}"]
+    ports:
+      - "8000:8000"
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    ports:
+      - "9090:9090"
+    depends_on:
+      - gateway
+    networks: ["${DOCKER_NETWORK:-aimnet}"]
+
+networks:
+  aimnet:
+    name: ${DOCKER_NETWORK:-aimnet}

--- a/infra/prometheus/prometheus.yml
+++ b/infra/prometheus/prometheus.yml
@@ -1,0 +1,13 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ["localhost:9090"]
+
+  - job_name: gateway
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["gateway:8000"]


### PR DESCRIPTION
## Summary
- add a FastAPI-based gateway service capable of simulating ticket.created events with idempotency handling and Prometheus metrics
- provide containerization assets, Kafka/Prometheus docker compose stack, and environment variables for the new gateway
- document usage and smoke tests for the simulator endpoint

## Testing
- not run (infrastructure-only change)


------
https://chatgpt.com/codex/tasks/task_e_6907b76549b083339dc8dd76e672cd88